### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go Outliner adds activity bar icon for code outline (Go projects only) to VS Cod
 
 Go-Outliner package needs to be installed for this extension to work
 
-    go get -u github.com/766b/go-outliner
+    go install github.com/766b/go-outliner
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
Changes `go get` to `go install`.  Since go 1.17, go get was deprecated as a way to install binaries in favor of go install.  Reference:  https://go.dev/doc/go-get-install-deprecation